### PR TITLE
PRO-1594 and PRO-1590

### DIFF
--- a/lib/boilerplate.js
+++ b/lib/boilerplate.js
@@ -121,11 +121,13 @@ module.exports = function (moduleName, options = {}) {
           </section>
         `,
         jsConfig: stripIndent`
-          apos.util.widgetPlayers['${moduleName}'] = {
-            selector: '[data-${moduleName}-widget]',
-            player: function(el) {
-              // Add player code
-            }
+          export default () => {
+            apos.util.widgetPlayers['${moduleName}'] = {
+              selector: '[data-${moduleName}-widget]',
+              player: function(el) {
+                // Add player code
+              }
+            };
           };
         `
       }

--- a/lib/commands/add-types/widget.js
+++ b/lib/commands/add-types/widget.js
@@ -33,10 +33,10 @@ module.exports = function(moduleName, majorVersion, options) {
   fs.writeFileSync(path.join(modulePath, 'index.js'), widgetsConfig);
 
   if (options.player) {
-    const playerFilename = majorVersion === '2' ? 'lean.js' : 'browser.js';
+    const playerFilename = majorVersion === '2' ? 'lean.js' : 'index.js';
     util.log('add widget', `Setting up ${playerFilename} for ${fullWidgetName}.`);
 
-    const jsDir = majorVersion === '2' ? 'public/js' : 'ui/public';
+    const jsDir = majorVersion === '2' ? 'public/js' : 'ui/src';
 
     mkdir('-p', path.join(modulePath, jsDir));
 

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -55,11 +55,13 @@ module.exports = function (program) {
 
       util.replaceInFiles([ './app.js' ], /disabledFileKey: undefined/, `disabledFileKey: '${secret}'`);
 
+      // Remove lock file and install packages.
       util.log('create', 'Installing packages [3/4]');
-      // Install, then update, so the lock file gets updated and we're not
-      // tied to a very old version of Apostrophe in the boilerplate lock file.
-      // Without "install" we do not get devDependencies, at least in npm 6.4.13.
-      exec('npm install && npm update --dev');
+
+      rm('package-lock.json');
+      rm('yarn.lock');
+
+      exec('npm install');
 
       const cwd = process.cwd();
       const aposPath = `${cwd}/node_modules/apostrophe`;

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -56,9 +56,10 @@ module.exports = function (program) {
       util.replaceInFiles([ './app.js' ], /disabledFileKey: undefined/, `disabledFileKey: '${secret}'`);
 
       util.log('create', 'Installing packages [3/4]');
-      // Update, not install, so the lock file gets updated and we're not
+      // Install, then update, so the lock file gets updated and we're not
       // tied to a very old version of Apostrophe in the boilerplate lock file.
-      exec('npm update --dev');
+      // Without "install" we do not get devDependencies, at least in npm 6.4.13.
+      exec('npm install && npm update --dev');
 
       const cwd = process.cwd();
       const aposPath = `${cwd}/node_modules/apostrophe`;


### PR DESCRIPTION
* Use ui/src, not ui/public, for widget players.
* Make sure devDependencies make it. "npm update --dev" ought to cover it, but doesn't, so we wind up with no nodemon unless we chain like this to get both the dev dependencies, and updated dependencies. Fortunately npm update is pretty fast at figuring out what is already correct.