### PR TITLE
pin to avoid the liberty bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.1 (2022-01-10)
+
+### Fixes
+
+- Pinned `package.json` to version `1.4.0` of the `colors` module to ensure the [liberty bug](https://github.com/Marak/colors.js/issues/285) does not corrupt the display. This should not be possible when installing normally with `-g` since we were already shipping a `package-lock.json` that contains 1.4.0, however the bug did occur if a user cloned the repo and ran `npm update`, so in an abundance of caution we are making sure it is not possible even when doing so.
+
 ## 3.1.0 (2021-10-14)
 
 ### Adds

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/apostrophecms/cli.git"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^5.1.0",
     "common-tags": "^1.8.0",
     "conf": "^6.2.4",


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Pins the `colors` module, closes #3611. This issue did not occur with regular `install -g` of the CLI but did occur if one git cloned it, npm updated it, and then tried to use that.

## What are the specific steps to test this change?

* git clone the repo (this branch)
* `npm update`
* `./bin/apostrophe create test-project`

You should get a normal project and no LIBERTY LIBERTY LIBERTY and other nonsense spewed on the display during the CLI run. The created project itself was never impacted to my knowledge, it impacted the CLI display.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [N/A] Related documentation has been updated
- [N/A] Related tests have been updated
