### PR TITLE
fix 'add --help' typo, refactor ora to dynamic import, move colors.js

### DIFF
--- a/bin/apostrophe
+++ b/bin/apostrophe
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 require('shelljs/global');
-require('colors');
 const { program } = require('commander');
 const util = require('../lib/util');
 const confUtils = require('../lib/conf-utils');

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -8,7 +8,7 @@ const { stripIndent } = require('common-tags');
 
 module.exports = function (program, version) {
   program
-    .command('add <module type> <module-name>')
+    .command('add <module-type> <module-name>')
     .description(stripIndent`
       Add an Apostrophe module with boilerplate configuration to get you started.
       - Add "module" for <module type> to add a generic module.

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,7 @@ const cliVersion = require('../package.json').version;
 const confUtils = require('./conf-utils');
 const packageJson = require('package-json');
 const semver = require('semver');
-const ora = require('ora');
+require('colors');
 const { spawn } = require('child_process');
 
 module.exports = util;
@@ -155,6 +155,7 @@ util.spawnWithSpinner = async function (command, options = {
     throw new Error('No command provided to spawnWithSpinner');
   }
 
+  const ora = await (await import('ora')).default;
   const spinner = ora({
     text: options.spinnerMessage,
     interval: 100,


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes 'add --help' typo, refactors ora to dynamic import statement, moves colors.js

## What are the specific steps to test this change?

*For example:*
> 1. Clone the repository
> 2. run 'npm i -D'
> 3. run ./bin/apostrophe add --help
> 4. run ./bin/apostrophe create (any name here)

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Moves "require('colors')" statement from bin/apostrophe to lib/util.js where it is used.

Fixes typo for "./bin/apostrophe add --help"
see https://asciinema.org/a/469939

Changes ora to dynamic import() statement
see https://github.com/sindresorhus/ora/issues/189

```sh
apostrophe-cms/cli/lib/util.js:12
const ora = require('ora');
            ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/admin/work/node/apostrophe-cms/cli/node_modules/.pnpm/ora@6.0.1/node_modules/ora/index.js from /Users/admin/work/node/apostrophe-cms/cli/lib/util.js not supported.
Instead change the require of index.js in /Users/admin/work/node/apostrophe-cms/cli/lib/util.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/admin/work/node/apostrophe-cms/cli/lib/util.js:12:13)
    at Object.<anonymous> (/Users/admin/work/node/apostrophe-cms/cli/bin/apostrophe:6:14) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v17.4.0
```
